### PR TITLE
Two small bugfix

### DIFF
--- a/dradismd.py
+++ b/dradismd.py
@@ -576,7 +576,7 @@ class DradisMD:
 
         # Append evidenceID to the local file : allows to update this evidence later on
         evidence.write_text(
-            f"{evidence_content}\n#[EvidenceID]#\n\n{evidence_id}\n",
+            f"{evidence_content}\n\n#[EvidenceID]#\n\n{evidence_id}\n",
             encoding="utf8",
             newline=LINE_RETURN,
             errors="ignore",
@@ -1147,14 +1147,14 @@ def arg_parser():
     parser_list.add_argument("--last", "-l", action="store", type=int, nargs="?", const=5)
 
     # get project:           get <projectid> <path> [--format <format>]
-    parser_import = subparsers.add_parser("get", aliases=("import"))
+    parser_import = subparsers.add_parser("get", aliases=("import","i"))
     parser_import.set_defaults(action="get")
     parser_import.add_argument("project_id", action="store")
     parser_import.add_argument("destination", action="store", nargs="?")
     parser_import.add_argument("--format", action="store", nargs="?", const=DEFAULT_FORMAT)
 
     # update project:           update <projectid> <file | folder>
-    parser_export = subparsers.add_parser("update", aliases=("export"))
+    parser_export = subparsers.add_parser("update", aliases=("export","u"))
     parser_export.set_defaults(action="update")
     parser_export.add_argument("project_id", action="store")
     parser_export.add_argument("path", action="store", nargs="?")

--- a/shell-completion/README.md
+++ b/shell-completion/README.md
@@ -6,3 +6,8 @@ Zsh completion script are located in this folder. The script should be copied in
 cp _dradismd /usr/share/zsh/vendor-completions/_dradismd
 ```
 
+Usual location on arch :
+
+```
+cp _dradismd /usr/share/zsh/site-functions/_dradismd
+```

--- a/shell-completion/_dradismd
+++ b/shell-completion/_dradismd
@@ -58,7 +58,7 @@ function _dradismd_projects {
 function _dradismd_get {
     # Getting list of id formated with Name of project as description 
     # Example : "001\:'project1' 002\:project2 003\:'project3'"
-    dradisId=$(dradismd project|tail -n +5|head -n -1|awk '{print $2 "\\\\:\\\x27" $4 "\\\x27"}'|xargs)
+    dradisId=$(dradismd project 2> /dev/null |tail -n +5|head -n -1|awk  -F│ '{gsub(/^[ \t]+|[ \t]+$/, "", $2);gsub(/^[ \t]+|[ \t]+$/, "", $3);if ($2) print $2 "\\\\:\\\x27" $3 "\\\x27"}'|xargs)
     _arguments \
 	    "1:project_id:(($dradisId))"\
 	    "2:destination_folder:_path_files"\
@@ -81,7 +81,7 @@ function _dradismd_add_issue {
 function _dradismd_update {
     # Getting list of id formated with Name of project as description 
     # Example : "001\:'project1' 002\:project2 003\:'project3'"
-    dradisId=$(dradismd project|tail -n +5|head -n -1|awk '{print $2 "\\\\:\\\x27" $4 "\\\x27"}'|xargs)
+    dradisId=$(dradismd project 2> /dev/null |tail -n +5|head -n -1|awk  -F│ '{gsub(/^[ \t]+|[ \t]+$/, "", $2);gsub(/^[ \t]+|[ \t]+$/, "", $3);if ($2) print $2 "\\\\:\\\x27" $3 "\\\x27"}'|xargs)
     _arguments \
 	"1:project_id:(($dradisId))"\
 	"2:Source folder:_path_files"


### PR DESCRIPTION
**First fix :**
In case of a file end with an image and no new line, the _EvidenceID_ was pasted the line below the image, which result to a parsing error in Dradis. 

The fix was to add a second new line before the _EvidenceID_ to be sure to have a full empty line between the content and the _EvidenceID_. 

**Second fix :**
The shell script parsing of the output for the ZSH auto completion was not robust enough and was upgraded.  